### PR TITLE
fix: correctly create string in bad pattern

### DIFF
--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -248,8 +248,9 @@ static inline void raise_bad_pattern(int code, size_t pos)
   CAMLparam0();
   CAMLlocal1(v_msg);
   value v_arg;
-  v_msg = caml_alloc_string(128);
-  pcre2_get_error_message(code, (PCRE2_UCHAR *)String_val(v_msg), 128);
+  char msg_buf[128];
+  pcre2_get_error_message(code, (PCRE2_UCHAR *)msg_buf, (sizeof msg_buf) / (sizeof (PCRE2_UCHAR)));
+  v_msg = caml_copy_string(msg_buf);
   v_arg = caml_alloc_small(2, 0);
   Field(v_arg, 0) = v_msg;
   Field(v_arg, 1) = Val_int(pos);

--- a/test/pcre2_tests.ml
+++ b/test/pcre2_tests.ml
@@ -9,8 +9,20 @@ let simple_test ctxt =
                   NoGroup; Group (2, "u"); Text "ef"]
       (full_split ~pat:"(x)|(u)" "abxcduef")
 
+let bad_pattern ctxt =
+  try
+    ignore (regexp "?");
+    assert_failure "Regex should fail to parse"
+  with Error (BadPattern (s, _)) ->
+    assert_bool
+      "String contains a zero byte. In 8-bit mode this indicates an error in \
+       the creation of the error message since strings created by PCRE2 should \
+       be null terminated."
+      (not @@ String.exists (fun c -> c = '\000') s)
+
 let suite = "Test pcre" >::: [
-      "simple_test"   >:: simple_test
+      "simple_test"   >:: simple_test;
+      "bad_pattern"   >:: bad_pattern
     ]
 
 let _ = 


### PR DESCRIPTION
Currently when an exception like `Pcre2.Error (BadPattern (s, i))` is raised, `s` is always a string of length 128. For example:
```
$ Pcre2.regexp "?";;
Exception:
Pcre2.Error
 (Pcre2.BadPattern
   ("quantifier does not follow a repeatable item\000\000\000\000\001\000\000\000\000\000\000\000\001\000\000\000\000\000\000\000\001\000\000\000\000\000\000\000ü\004\000\000\000\000\000\000 \000\000\000\000\000\000\006\000\004\000\000\000\000\000\000ðø\0198\001\000\000\000\000\004\000\000\000\000\000\000\024\0218\001\000\000\000\000\028\000\000\000\000\000\000",
   0)).
```
The contents appear to just be garbage left in the buffer beyond the null terminator added by pcre.

This PR fixes the issue by creating a string using `caml_copy_string` instead of just writing into the buffer. Additionally, the length which was previously passed was expressed in terms of bytes, not PCRE2 code units.

I re-use the current buffer size of 128 bytes for the error message string; ideally we would resize the buffer if pcre2_get_error_message returned PCRE2_ERROR_NOMEMORY, but I haven't done so for simplicity here.