### PR TITLE
Fix compilation warnings; OCaml 5 volatile correctness

### DIFF
--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -202,27 +202,27 @@ static inline void raise_pcre2_error(value v_arg)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-static inline void raise_partial()
+static inline void raise_partial(void)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-static inline void raise_bad_utf()
+static inline void raise_bad_utf(void)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-static inline void raise_bad_utf_offset()
+static inline void raise_bad_utf_offset(void)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-static inline void raise_match_limit()
+static inline void raise_match_limit(void)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-static inline void raise_depth_limit()
+static inline void raise_depth_limit(void)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-static inline void raise_workspace_size()
+static inline void raise_workspace_size(void)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
@@ -236,12 +236,12 @@ CAMLnoreturn_end;
 static inline void raise_pcre2_error(value v_arg)
 { caml_raise_with_arg(*pcre2_exc_Error, v_arg); }
 
-static inline void raise_partial() { raise_pcre2_error(Val_int(0)); }
-static inline void raise_bad_utf() { raise_pcre2_error(Val_int(1)); }
-static inline void raise_bad_utf_offset() { raise_pcre2_error(Val_int(2)); }
-static inline void raise_match_limit() { raise_pcre2_error(Val_int(3)); }
-static inline void raise_depth_limit() { raise_pcre2_error(Val_int(4)); }
-static inline void raise_workspace_size() { raise_pcre2_error(Val_int(5)); }
+static inline void raise_partial(void) { raise_pcre2_error(Val_int(0)); }
+static inline void raise_bad_utf(void) { raise_pcre2_error(Val_int(1)); }
+static inline void raise_bad_utf_offset(void) { raise_pcre2_error(Val_int(2)); }
+static inline void raise_match_limit(void) { raise_pcre2_error(Val_int(3)); }
+static inline void raise_depth_limit(void) { raise_pcre2_error(Val_int(4)); }
+static inline void raise_workspace_size(void) { raise_pcre2_error(Val_int(5)); }
 
 static inline void raise_bad_pattern(int code, size_t pos)
 {

--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -30,9 +30,9 @@
 #endif
 
 #if _WIN64
-  typedef long long *caml_int_ptr;
+  typedef volatile long long *caml_int_ptr;
 #else
-  typedef long *caml_int_ptr;
+  typedef volatile long *caml_int_ptr;
 #endif
 
 #if __GNUC__ >= 3
@@ -481,7 +481,7 @@ static inline void handle_match_error(char *loc, const int ret)
 static inline void handle_pcre2_match_result(
   size_t *ovec, value v_ovec, size_t ovec_len, long subj_start, uint32_t ret)
 {
-  caml_int_ptr ocaml_ovec = (caml_int_ptr) &Field(v_ovec, 0);
+  caml_int_ptr ocaml_ovec = &Field(v_ovec, 0);
   const uint32_t subgroups2 = ret * 2;
   const uint32_t subgroups2_1 = subgroups2 - 1;
   const size_t *ovec_src = ovec + subgroups2_1;
@@ -594,8 +594,7 @@ CAMLprim value pcre2_match_stub0(
       } else {
         handle_pcre2_match_result(ovec, v_ovec, ovec_len, subj_start, ret);
         if (is_dfa) {
-          caml_int_ptr ocaml_workspace_dst =
-            (caml_int_ptr) &Field(v_workspace, 0);
+          caml_int_ptr ocaml_workspace_dst = &Field(v_workspace, 0);
           const int *workspace_src = workspace;
           const int *workspace_src_stop = workspace + workspace_len;
           while (workspace_src != workspace_src_stop) {


### PR DESCRIPTION
This patch fixes a number of compilation warnings that arose when compiling `pcre2_stubs.c` under Apple Clang 14.0.3 with the standard compilation flags as defined in the `dev` dune `env`ironment. Additionally, in so doing, it resolves a number of `volatile` cast warnings that could cause memory consistency issues when paired with the OCaml 5 runtime.